### PR TITLE
Create the smartling-config file for legal docs - test select files in select languages

### DIFF
--- a/legal-test/configs/smartling-config.json
+++ b/legal-test/configs/smartling-config.json
@@ -16,9 +16,9 @@
             "application": "nl"
         },
         {
-            "smartling": "fr-CA",
-            "application": "fr-CA"
-        },
+            "smartling": "nl-BE",
+            "application": "nl-BE"
+        },                
         {
             "smartling": "fr-FR",
             "application": "fr"
@@ -48,6 +48,10 @@
             "application": "ko"
         },
         {
+            "smartling": "ms-MS",
+            "application": "ms"
+        },
+        {
             "smartling": "pl-PL",
             "application": "pl"
         },
@@ -74,6 +78,10 @@
         {
             "smartling": "es-ES",
             "application": "es-ES"
+        },
+        {
+            "smartling": "sw",
+            "application": "sw"
         },
         {
             "smartling": "tr-TR",

--- a/legal-test/configs/smartling-config.json
+++ b/legal-test/configs/smartling-config.json
@@ -1,0 +1,99 @@
+{
+    "locales": [{
+            "smartling": "ar",
+            "application": "ar"
+        },
+        {
+            "smartling": "zh-CN",
+            "application": "zh-CN"
+        },
+        {
+            "smartling": "zh-TW",
+            "application": "zh-TW"
+        },
+        {
+            "smartling": "nl-NL",
+            "application": "nl"
+        },
+        {
+            "smartling": "fr-CA",
+            "application": "fr-CA"
+        },
+        {
+            "smartling": "fr-FR",
+            "application": "fr"
+        },
+        {
+            "smartling": "de-DE",
+            "application": "de"
+        },
+        {
+            "smartling": "hi-IN",
+            "application": "hi-IN"
+        },
+        {
+            "smartling": "id-ID",
+            "application": "id"
+        },
+        {
+            "smartling": "it-IT",
+            "application": "it"
+        },
+        {
+            "smartling": "ja-JP",
+            "application": "ja"
+        },
+        {
+            "smartling": "ko-KR",
+            "application": "ko"
+        },
+        {
+            "smartling": "pl-PL",
+            "application": "pl"
+        },
+        {
+            "smartling": "pt-BR",
+            "application": "pt-BR"
+        },
+        {
+            "smartling": "pt-PT",
+            "application": "pt-PT"
+        },
+        {
+            "smartling": "ru-RU",
+            "application": "ru"
+        },
+        {
+            "smartling": "es",
+            "application": "es"
+        },
+        {
+            "smartling": "es-MX",
+            "application": "es-MX"
+        },
+        {
+            "smartling": "es-ES",
+            "application": "es-ES"
+        },
+        {
+            "smartling": "tr-TR",
+            "application": "tr"
+        },
+        {
+            "smartling": "vi-VN",
+            "application": "vi"
+        }
+    ],
+    "resourceSets": [{
+        "pathRegex": "legal-test\\/en\\/(?<filename>(firefox_privacy_notice|websites_privacy_notice))\\.md",
+        "translationPathExpression": "legal-test/${locale}/${filename}_sl.${originalFile.extension}",
+        "translationCommitMessage": "Translate ${originalFile.fullName} to ${locale}",
+        "locales": [
+            {
+                "smartling" : "es-ES",
+                "application" : "es-ES"
+            },{
+                "smartling" : "zh-CN",
+                "application" : "zh-CN"
+            }
+        ] 


### PR DESCRIPTION
This is for testing only for two files in the new file structure. This configuration allows the PM to select requested docs to be localized in certain locales.  The test purpose is to:
- Only specified  files in select locales are pulled to Smartling platform.
- Localize docs are pushed back to the repo with a **sl** in the file names
- Review markups in the docs and the layout.